### PR TITLE
Relax poison requirements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule InchEx.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:poison, "~> 2.0"}
+      {:poison, "~> 1.5 or ~> 2.0"}
     ]
   end
 end


### PR DESCRIPTION
Since inch_ex doesn't rely on poison 2.0 feature it's fine to support
the 1.x branch as well.

Sorry @rrrene for the double PR and inconvenience :(