### PR TITLE
Dependency `credo` only for dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule InchEx.Mixfile do
   defp deps do
     [
       {:poison, "~> 1.5 or ~> 2.0"},
-      {:credo, "~> 0.4"}
+      {:credo, "~> 0.4", only: :dev}
     ]
   end
 end


### PR DESCRIPTION
Updating inch_ex to 0.5.2 in an app causes mix.lock to add credo to the project as well.
wdyt of restricting credo as a dev dependency for inch_ex? Makes sense?