### PR TITLE
Fix Determination of CircleCI Validity

### DIFF
--- a/lib/inch_ex/reporter/remote.ex
+++ b/lib/inch_ex/reporter/remote.ex
@@ -42,6 +42,8 @@ defmodule InchEx.Reporter.Remote do
 
   # We do not want data from builds which only validate PRs
   defp valid?(:circleci) do
-    is_nil(System.get_env("CI_PULL_REQUEST"))
+    pr = System.get_env("CI_PULL_REQUEST")
+
+    is_nil(pr) || pr == ""
   end
 end


### PR DESCRIPTION
CircleCI now sets the value of the system environment variable `CI_PULL_REQUEST` to an empty value. This means that Elixir will determine the variable to be present and return an empty string for its value; not `nil`. This change appropriately detects that pull requests are signified by non-empty strings.

I have left the previous check for `nil` in as well in case Circle's platform is inconsistent.