### PR TITLE
Fix deprecation warning raised by inch.ex

### DIFF
--- a/lib/mix/tasks/inch.ex
+++ b/lib/mix/tasks/inch.ex
@@ -32,7 +32,7 @@ defmodule Mix.Tasks.Inch do
       cond do
         is_nil(options[:main]) ->
           # Try generating main module's name from the app name
-          Keyword.put(options, :main, (config[:app] |> Atom.to_string |> Mix.Utils.camelize))
+          Keyword.put(options, :main, (config[:app] |> Atom.to_string |> Macro.camelize))
 
         is_atom(options[:main]) ->
           Keyword.update!(options, :main, &inspect/1)


### PR DESCRIPTION
```
warning: Mix.Utils.camelize/1 is deprecated, use Macro.camelize/1 instead
  (mix) lib/mix/utils.ex:250: Mix.Utils.camelize/1
  lib/mix/tasks/inch.ex:35: Mix.Tasks.Inch.run/4
  (mix) lib/mix/task.ex:294: Mix.Task.run_task/3
  (mix) lib/mix/project.ex:313: Mix.Project.in_project/4
  (elixir) lib/file.ex:1162: File.cd!/2
```