### PR TITLE
Fix Elixir 1.5 compile warnings

### DIFF
--- a/lib/inch_ex/git.ex
+++ b/lib/inch_ex/git.ex
@@ -33,8 +33,8 @@ defmodule InchEx.Git do
 
   defp git_output(args) do
     case System.cmd("git", args) do
-      {output, 0} -> String.strip(output)
-      {output, _} -> String.strip(output)
+      {output, 0} -> String.trim(output)
+      {output, _} -> String.trim(output)
     end
   end
 

--- a/lib/inch_ex/reporter/local.ex
+++ b/lib/inch_ex/reporter/local.ex
@@ -30,7 +30,7 @@ defmodule InchEx.Reporter.Local do
   defp inch_cli_api_endpoint do
     case System.get_env("INCH_CLI_API") do
       nil -> @cli_api_end_point
-      url -> to_char_list url
+      url -> to_charlist url
     end
   end
 

--- a/lib/inch_ex/reporter/remote.ex
+++ b/lib/inch_ex/reporter/remote.ex
@@ -22,7 +22,7 @@ defmodule InchEx.Reporter.Remote do
   defp inch_build_api_endpoint do
     case System.get_env("INCH_BUILD_API") do
       nil -> @build_api_end_point
-      url -> url |> String.to_char_list
+      url -> url |> String.to_charlist
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule InchEx.Mixfile do
   defp deps do
     [
       {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
-      {:credo, "~> 0.4", only: :dev}
+      {:credo, "~> 0.8", only: :dev}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
-  "credo": {:hex, :credo, "0.4.0", "ab0b8ee2a742ef4b7c8612c55f03cab11d6d1d258d98b3c03572d01909590674", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
-  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []}}
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.8.1", "137efcc99b4bc507c958ba9b5dff70149e971250813cbe7d4537ec7e36997402", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], [], "hexpm"}}


### PR DESCRIPTION
This is mainly to silence compile warnings that were added in Elixir 1.5
* `to_char_list` -> `to_charlist`
* `Enum.filter_map/3` -> `Enum.filter/2 |> Enum.map/2`

If you prefer, I could make the filter |> map into a list comprehension
instead.

I also cleaned up some credo warnings that were in the files I touched, and updated the credo version to the latest.

Cheers!