### PR TITLE
Ignore files without docs chunk present

### DIFF
--- a/lib/inch_ex/code_object.ex
+++ b/lib/inch_ex/code_object.ex
@@ -17,6 +17,9 @@ defmodule InchEx.CodeObject do
     |> Enum.map(&prepare(&1, list))
     |> Enum.map(&transform/1)
   end
+  
+  # Ignore files without docs chunk
+  def eval(nil), do: []
 
   @doc "Injects additional attributes into the given map"
   def cast(item)


### PR DESCRIPTION
This seems to be a minimal fix, so at least it does not fail anymore. I'm not sure if there's a way to have the file still be reported as undocumented or if there's data in the docs chunk that's necessary for doing that.

https://github.com/rrrene/inch_ex/issues/67