### PR TITLE
Fix branch_name in CI and refactor Env out

### DIFF
--- a/lib/inch_ex/cli/commands/report_command.ex
+++ b/lib/inch_ex/cli/commands/report_command.ex
@@ -1,7 +1,7 @@
 defmodule InchEx.CLI.Commands.ReportCommand do
-  @env_var_skip_report "INCH_SKIP_REPORT"
   @build_api_end_point "https://inch-ci.org/api/v2/builds"
 
+  alias InchEx.CLI.Env
   alias InchEx.CLI.Options
   alias InchEx.CodeObject
   alias InchEx.Docs
@@ -10,7 +10,7 @@ defmodule InchEx.CLI.Commands.ReportCommand do
 
   @doc false
   def call(argv) do
-    if valid?() do
+    if Env.valid?() do
       options = Options.parse(argv)
 
       options
@@ -18,7 +18,7 @@ defmodule InchEx.CLI.Commands.ReportCommand do
       |> fetch_and_evaluate_docs()
       |> send_results(inch_build_api_endpoint())
     else
-      ReportOutput.handle_error("InchEx skipped (reason: #{reason_for_invalidity()}).")
+      ReportOutput.handle_error("InchEx skipped (reason: #{Env.reason_for_invalidity()}).")
     end
   end
 
@@ -52,64 +52,4 @@ defmodule InchEx.CLI.Commands.ReportCommand do
     ReportOutput.call(results, url)
   end
 
-  # We do not want data from builds which only validate PRs
-  defp valid? do
-    if System.get_env(@env_var_skip_report) == "true" do
-      false
-    else
-      env() |> valid?()
-    end
-  end
-
-  defp reason_for_invalidity do
-    if System.get_env(@env_var_skip_report) == "true" do
-      "#{@env_var_skip_report} set to true"
-    else
-      env() |> reason_for_invalidity()
-    end
-  end
-
-  defp reason_for_invalidity(:circleci), do: "pull request on Circle CI"
-  defp reason_for_invalidity(:travis), do: "pull request on Travis CI"
-  defp reason_for_invalidity(_), do: "could not detect CI service"
-
-  # We do not want data from builds which only validate PRs
-  defp valid?(:travis) do
-    System.get_env("TRAVIS_PULL_REQUEST") == "false"
-  end
-
-  # We do not want data from builds which only validate PRs
-  defp valid?(:circleci) do
-    pr = System.get_env("CI_PULL_REQUEST")
-
-    is_nil(pr) || pr == ""
-  end
-
-  defp valid?(:generic_ci), do: true
-
-  defp valid?(_), do: false
-
-  defp env do
-    cond do
-      circleci?() -> :circleci
-      travis?() -> :travis
-      generic_ci?() -> :generic_ci
-      true -> :unknown
-    end
-  end
-
-  # Returns true if not run on any known CI, but seems to be on CI.
-  defp generic_ci? do
-    !circleci?() && !travis?() && System.get_env("CI") == "true"
-  end
-
-  # Returns true if run on CircleCI.
-  defp circleci? do
-    System.get_env("CIRCLECI") == "true"
-  end
-
-  # Returns true if run on Travis.
-  defp travis? do
-    System.get_env("TRAVIS") == "true"
-  end
 end

--- a/lib/inch_ex/cli/env.ex
+++ b/lib/inch_ex/cli/env.ex
@@ -1,0 +1,65 @@
+defmodule InchEx.CLI.Env do
+  @env_var_skip_report "INCH_SKIP_REPORT"
+
+  def env do
+    cond do
+      circleci?() -> :circleci
+      travis?() -> :travis
+      generic_ci?() -> :generic_ci
+      true -> :unknown
+    end
+  end
+
+  # We do not want data from builds which only validate PRs
+  def valid? do
+    if System.get_env(@env_var_skip_report) == "true" do
+      false
+    else
+      env() |> valid?()
+    end
+  end
+
+  # We do not want data from builds which only validate PRs
+  defp valid?(:travis) do
+    System.get_env("TRAVIS_PULL_REQUEST") == "false"
+  end
+
+  # We do not want data from builds which only validate PRs
+  defp valid?(:circleci) do
+    pr = System.get_env("CI_PULL_REQUEST")
+
+    is_nil(pr) || pr == ""
+  end
+
+  defp valid?(:generic_ci), do: true
+
+  defp valid?(_), do: false
+
+
+  @doc "Returns true if not run on any known CI, but seems to be on CI."
+  def generic_ci? do
+    !circleci?() && !travis?() && System.get_env("CI") == "true"
+  end
+
+  @doc "Returns true if run on CircleCI."
+  def circleci? do
+    System.get_env("CIRCLECI") == "true"
+  end
+
+  @doc "Returns true if run on Travis."
+  def travis? do
+    System.get_env("TRAVIS") == "true"
+  end
+
+  def reason_for_invalidity do
+    if System.get_env(@env_var_skip_report) == "true" do
+      "#{@env_var_skip_report} set to true"
+    else
+      env() |> reason_for_invalidity()
+    end
+  end
+
+  defp reason_for_invalidity(:circleci), do: "pull request on Circle CI"
+  defp reason_for_invalidity(:travis), do: "pull request on Travis CI"
+  defp reason_for_invalidity(_), do: "could not detect CI service"
+end

--- a/lib/inch_ex/cli/git.ex
+++ b/lib/inch_ex/cli/git.ex
@@ -3,6 +3,8 @@ defmodule InchEx.CLI.Git do
     Provide information about the Git repo in the cwd.
   """
 
+  alias InchEx.CLI.Env
+
   @doc """
     Returns true if there are any modified or untracked files in the
     working dir.
@@ -23,7 +25,11 @@ defmodule InchEx.CLI.Git do
 
   @doc "Returns the name of the current branch."
   def branch_name do
-    git_output(["rev-parse", "--abbrev-ref", "HEAD"])
+    case Env.env() do
+      :travis -> System.get_env("TRAVIS_BRANCH")
+      :circleci -> System.get_env("CIRCLE_BRANCH")
+      _ -> git_output(["rev-parse", "--abbrev-ref", "HEAD"])
+    end
   end
 
   @doc "Returns the SHA1 of the current revision."


### PR DESCRIPTION
Resolves #70 

On older versions, there's this part of the code:
```elixir
data =
      case InchEx.Env.env do
        :travis ->
          data
          |> Map.put(:travis, true)
          |> Map.put(:travis_job_id, System.get_env("TRAVIS_JOB_ID"))
          |> Map.put(:branch_name, System.get_env("TRAVIS_BRANCH"))

        :circleci ->
          data
          |> Map.put(:circleci, true)
          |> Map.put(:branch_name, System.get_env("CIRCLE_BRANCH"))

        :generic_ci ->
          data
          |> Map.put(:ci, true)
          |> Map.put(:branch_name, InchEx.Git.branch_name)

        _ ->
          data
          |> Map.put(:shell, true)
          |> Map.put(:branch_name, InchEx.Git.branch_name)
      end
```

Of particular note is the `:branch_name` data

However, currently the repo has been refactored a lot, so I'm not sure how to add the code. I tried to refactor the code. Let me know if I should organise the code another way.