### PR TITLE
Output raw numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ mix inch
 ┃  U  ↑  Foo
 ┃  U  ↗  Foo.filename/1
 
-Grade distribution (undocumented, C, B, A):  █  ▁ ▄ ▄
+Grade distribution (A, B, C, undocumented): ▄ ▄ ▁ █
 ```
 
 
@@ -109,7 +109,7 @@ Inch does not give you a grade for your whole codebase.
 
 "Why?" you might ask. Look at the example below:
 
-    Grade distribution (undocumented, C, B, A):  ▄  ▁ ▄ █
+    Grade distribution (A, B, C, undocumented): █ ▄ ▁ ▄
 
 In this example there is a part of code that is still undocumented, but
 the vast majority of code is rated A or B.

--- a/lib/inch_ex/cli/commands/suggest_output.ex
+++ b/lib/inch_ex/cli/commands/suggest_output.ex
@@ -1,5 +1,5 @@
 defmodule InchEx.CLI.Commands.SuggestOutput do
-  @distribution_grades ~w(U C B A)
+  @distribution_grades ~w(A B C U)
   @suggest_grades ~w(B C U)
 
   alias InchEx.CLI
@@ -118,7 +118,7 @@ defmodule InchEx.CLI.Commands.SuggestOutput do
     values = Enum.join(distribution, ", ")
 
     UI.puts()
-    UI.puts(["Grade distribution (undocumented, C, B, A): ", sparkline])
+    UI.puts(["Grade distribution (A, B, C, undocumented): ", sparkline])
     UI.puts(["Grade values: ", values])
     UI.puts()
     UI.puts([:faint, "Only considering priority objects: ↑ ↗ →  (use `--help` for options)."])

--- a/lib/inch_ex/cli/commands/suggest_output.ex
+++ b/lib/inch_ex/cli/commands/suggest_output.ex
@@ -115,8 +115,11 @@ defmodule InchEx.CLI.Commands.SuggestOutput do
         [Enum.at(colors, index), value, " "]
       end)
 
+    values = Enum.join(distribution, ", ")
+
     UI.puts()
     UI.puts(["Grade distribution (undocumented, C, B, A): ", sparkline])
+    UI.puts(["Grade values: ", values])
     UI.puts()
     UI.puts([:faint, "Only considering priority objects: ↑ ↗ →  (use `--help` for options)."])
   end


### PR DESCRIPTION
This shows the numbers that make up the distribution, and also changes the distribution order to match the Inch web UI/CLI badge generator.