### PR TITLE
support elixir 1.12 public functions empty docs format

### DIFF
--- a/lib/inch_ex/docs.ex
+++ b/lib/inch_ex/docs.ex
@@ -78,6 +78,7 @@ defmodule InchEx.Docs do
   defp docstring(%{"en" => docstring}), do: docstring
   defp docstring(:hidden), do: false
   defp docstring(:none), do: nil
+  defp docstring(%{}), do: nil
 
   defp private?(%{"doc" => false}), do: true
   defp private?(_), do: false


### PR DESCRIPTION
commit descr.
```
From elixir 1.12-rc0 changelog
[Kernel] Public functions without documentation now appear as an empty map on
Code.fetch_docs/1, unless they start with underscore, where they remain as
:none. This aligns Elixir's implementation with EEP48
```

Tests do not work on my machine even when using the versions specified in `.tool-versions` with asdf. So I did not bother to fix them (edit: because I don't know how :D ).