### PR TITLE
fix warning because jason app is not declared as dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,10 @@ defmodule InchEx.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [mod: {InchEx.Application, []}, applications: [:bunt, :logger, :inets]]
+    [
+      mod: {InchEx.Application, []},
+      extra_applications: [:logger, :inets]
+    ]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
With recent elixir versions (1.11 and 1.12), I get : 

```
==> inch_ex
Compiling 27 files (.ex)
warning: Jason.encode!/2 defined in application :jason is used by the current application but the current application does not depend on :jason. To fix this, you must do one of:

  1. If :jason is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :jason is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :jason, you may optionally skip this warning by adding [xref: [exclude: [Jason]]] to your "def project" in mix.exs

  lib/inch_ex/json.ex:5: InchEx.JSON.encode!/1

```

The fix consists in letting mix expand the dependent applications from the list of dependencies instead of overriding them with the `:applications` key in the project application definition.

Ref : https://hexdocs.pm/mix/Mix.Tasks.Compile.App.html